### PR TITLE
chore: generate and publish vs code extension vsix to the fleet release

### DIFF
--- a/.github/workflows/publish-naftiko-vscode-vsix.yml
+++ b/.github/workflows/publish-naftiko-vscode-vsix.yml
@@ -1,0 +1,57 @@
+name: Publish Naftiko VSCode VSIX
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout naftiko/fabric repository
+        uses: actions/checkout@v5
+        with:
+          repository: naftiko/fabric
+          # naftiko/fabric is private, use a secret PAT with repo access to naftiko/fabric
+          token: ${{ secrets.FABRIC_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/vscode-naftiko/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend/vscode-naftiko
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Package extension
+        run: vsce package
+        working-directory: frontend/vscode-naftiko
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: vscode-naftiko-vsix
+          path: frontend/vscode-naftiko/*.vsix
+
+      - name: Publish to GitHub Releases (fleet)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VSIX=$(ls frontend/vscode-naftiko/*.vsix | head -1)
+          gh release create "${{ github.ref_name }}" \
+            --repo ${{ github.repository }} \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes \
+            "$VSIX"


### PR DESCRIPTION
@eskenazit to test this github action, we must add a Private Access Token with fabric access in secrets named FABRIC_PAT