### PR TITLE
chore: update the name of the secret used in github action

### DIFF
--- a/.github/workflows/publish-naftiko-vscode-vsix.yml
+++ b/.github/workflows/publish-naftiko-vscode-vsix.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: naftiko/fabric
           # naftiko/fabric is private, use a secret PAT with repo access to naftiko/fabric
-          token: ${{ secrets.FABRIC_PAT }}
+          token: ${{ secrets.FABRIC_CONTENTS_READ }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
Just rename the secret accordingly to the ADR.
I made a manual test and it works well