### PR TITLE
docs: refresh Fleet README for alpha4 and link the live Playground

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,45 +1,5 @@
 NAFTIKO END USER LICENSE AGREEMENT (EULA)
 PRODUCT: Naftiko Fleet
 
-VERSION: 1.0 Alpha 3
-
-LICENSE TYPE: Freeware (Closed Source)
-
-1. GRANT OF LICENSE
-Naftiko hereby grants you a non-exclusive, non-transferable, royalty-free license to use the Naftiko Fleet (the "Software") for personal or internal business purposes. You may install and use the Software on any number of devices under your direct control.
-
-2. PROPRIETARY RIGHTS AND SOURCE CODE
-The Software is the intellectual property of, and is owned by, Naftiko. The Software is licensed, not sold.
-
-Closed Source: This license does not grant you any rights to the source code of the Software.
-
-Confidentiality: The internal logic, algorithms, and structure of the Software are trade secrets of Naftiko.
-
-3. RESTRICTIONS
-To maintain the integrity and security of Naftiko products, you agree not to:
-
-Decompile, disassemble, or reverse engineer the Software.
-
-Modify, "crack," or create derivative works based on the Software.
-
-Rent, lease, or sublicense the Software for commercial gain.
-
-Remove or obscure any copyright notices or Naftiko branding.
-
-4. REDISTRIBUTION
-You may redistribute the Software provided that:
-
-The installer package remains intact and unmodified.
-
-No fee is charged for the Software itself.
-
-Credit is clearly given to Naftiko.
-
-5. DISCLAIMER OF WARRANTY
-THE SOFTWARE IS PROVIDED BY NAFTIKO "AS IS" AND "WITH ALL FAULTS." NAFTIKO MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE SAFETY, SUITABILITY, OR ACCURACY OF THE SOFTWARE. YOU ARE SOLELY RESPONSIBLE FOR DETERMINING WHETHER THIS SOFTWARE IS COMPATIBLE WITH YOUR EQUIPMENT.
-
-6. LIMITATION OF LIABILITY
-IN NO EVENT SHALL NAFTIKO BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES (INCLUDING LOSS OF DATA OR PROFIT) ARISING OUT OF THE USE OR INABILITY TO USE THE SOFTWARE, EVEN IF NAFTIKO HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GOVERNING LAW
-This Agreement shall be governed by and construed in accordance with the laws of Delaware, without regard to its conflict of law principles.
+The product is free for testing while we define the proper packaging and licensing.
+All Rights Reserved, Naftiko Inc.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Naftiko Fleet — Community Edition
+# Naftiko Fleet
 
-[![License](https://img.shields.io/badge/License-Freeware_EULA-blue.svg)](https://github.com/naftiko/fleet/blob/main/LICENSE.md)
-
-Welcome to the **Naftiko Fleet**, the product platform for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/spec-driven-integration/) — reinventing API integration for the AI era with governed, versatile **capabilities** that streamline the API sprawl created by massive SaaS and microservices growth.
+Welcome to the **Naftiko Fleet**, the Enterprise platform for [Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha4/concepts/spec-driven-integration/) — reinventing API integration for the AI era with governed, versatile **capabilities** that streamline the API sprawl created by massive SaaS and microservices growth.
 
 > A *fleet* is what you call a group of ships sailing together — here, a group of capabilities running and governed as one.
 
@@ -10,85 +8,38 @@ Welcome to the **Naftiko Fleet**, the product platform for [Spec-Driven Integrat
 
 ## What the Fleet is
 
-The Naftiko Fleet delivers Spec-Driven Integration **end to end**, from authoring a capability to running, governing, and orchestrating it at scale. It is composed of **six focused components** that each own one step of the workflow, and is available in **three editions** — Community, Standard, and Enterprise.
+The Naftiko Fleet delivers Spec-Driven Integration **end to end**, from authoring a capability to operating and governing it at scale. It is composed of **three product components** that each own one step of the workflow.
 
-```text
- Discover ──► Author ──► Lint ──► Run ──► Govern ──► Orchestrate
-    │           │         │        │         │             │
- Shipyard    Crafter   Polychro  Ikanos    Warden      Skipper
-    │           │         │        │         │             │
-  (docs &     (UI &     (CI &    (engine   (policy      (fleet-wide
-   search)    spec      local    runtime)  enforcement) routing &
-              editor)   valid.)                         placement)
-```
-
-Crafter generates specs that Ikanos runs and Polychro validates. Warden sits between Crafter and Ikanos in regulated environments, enforcing policy before specs are deployed. Skipper coordinates many Ikanos processes across many clusters. Shipyard is where you learn about all of them — and soon, where you try them in a hosted Playground.
-
-> **Fleet vs fleet** — Capitalised **Fleet** always refers to the Naftiko Fleet, the product platform. Lowercase **fleet** refers to a group of capabilities running together at runtime (a *ship cluster*). Skipper orchestrates the latter on behalf of the former.
+ - Crafter is an **extension for VS Code** compatible IDEs to edit Ikanos specs and lint them with Polychro,
+ - Warden is a **Backstage integration** to help with cataloguing, scaffolding and delivery of Ikanos capabilities,
+ - Skipper is a **Kubernetes integration** to deploy and operate a fleet of capabilities.
 
 ## What the Fleet is *not*
 
-- **Not a single monolithic product.** The Fleet is six independently usable components, not one binary. You can adopt Ikanos and Polychro on their own under Apache 2.0, and add Crafter, Warden, or Skipper when you need them.
-- **Not a paywall on the essentials.** Every edition ships *every* component. **Ikanos** and **Polychro** are fully open-source — the same Apache 2.0 binary in every edition, with no premium features, forever. Editions only add team- and enterprise-grade features on top of Shipyard, Crafter, Warden, and Skipper.
-- **Not an all-or-nothing platform.** Components compose, but none requires the others. Use Polychro in CI without Ikanos, run Ikanos without Skipper, or document with Shipyard alone — each is valuable standalone.
-
-## Components
-
-With the Alpha 3 release, all six components are shipping software.
-
-| Component | Role | Edition / Version |
-|---|---|---|
-| [Shipyard](https://shipyard.naftiko.io/docs/1.0.0-alpha3/) | Documentation hub for the Fleet — soon a hosted Playground and AI-assisted search | Live |
-| [Ikanos](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/) | The capability engine — runs a Naftiko spec as a multi-protocol server (100% OSS) | v1.0.0-alpha3 |
-| [Polychro](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/) | The deterministic AI-era linter for YAML, JSON, and Markdown (100% OSS) | v1.0.0-alpha3 |
-| [Crafter](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/crafter/) | Capability builder — local-first today, hosted web UI in Standard | v1.0.0-alpha3 |
-| [Warden](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/warden/) | Capability governance and policy enforcement | v1.0.0-alpha3 |
-| [Skipper](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/skipper/) | Fleet-wide orchestration across teams, regions, and compliance domains | v1.0.0-alpha3 |
-
-## Editions
-
-The three editions do not differ by *which* components they include — every edition ships every component. What changes is the set of premium features layered on top of Shipyard, Crafter, Warden, and Skipper as you move up.
-
-| Edition | For | Deployment | What you get |
-|---|---|---|---|
-| **Community** | Open-source developers, individuals, OSS projects | Self-hosted | Every component, no premium add-ons — free for personal and internal business use |
-| **Standard** | Teams and small organizations | Self-hosted or cloud | Team-grade features for Shipyard, Crafter, Warden, Skipper |
-| **Enterprise** | Regulated enterprises | Self-hosted, air-gapped, or managed | Governance + scale for Shipyard, Crafter, Warden, Skipper |
-
-> Ikanos and Polychro are committed to staying **100% Apache 2.0 OSS** — identical in every edition, with no premium features and no commercial add-ons.
-
-For the full per-component premium-feature matrix and detailed edition pages, see [Fleet → Editions](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/editions/) on the Shipyard.
-
-## Licensing at a glance
-
-- The **Naftiko Fleet — Community Edition** is distributed under a **Freeware (Closed Source) EULA** — free of charge for personal or internal business use. See [the EULA](https://github.com/naftiko/fleet/blob/main/LICENSE.md).
-- **Ikanos** and **Polychro** are released as fully **Apache 2.0** open-source projects in their own repositories. You can use them standalone — outside of the Fleet — under Apache 2.0 terms.
-- **Standard** and **Enterprise** premium features are dual-licensed under the **Naftiko Commercial License**.
-
-> The full three-license picture is on the [License page](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/license/).
-
-***
+- **Not a single monolithic product.** The Fleet is three independently usable components, not one binary. You can adopt Crafter, Warden, or Skipper only when you need them.
+- **Not a paywall on the essentials.** The fleet always relies on **Ikanos** and **Polychro** which are fully open-source (Apache 2.0).
+- **Not an all-or-nothing platform.** Components compose, but none requires the others.
 
 ## :anchor: Dive deeper on the Shipyard
 
 The complete, always-up-to-date Fleet documentation lives on the **Naftiko Shipyard**. Start here and keep exploring:
 
-- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/concepts/spec-driven-integration/)
-- :ship: [Fleet Overview](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/)
-- :anchor: [Ikanos — the capability engine](https://shipyard.naftiko.io/docs/1.0.0-alpha3/ikanos/)
-- :mag: [Polychro — the spec linter](https://shipyard.naftiko.io/docs/1.0.0-alpha3/polychro/)
-- :hammer_and_wrench: [Crafter — the capability builder](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/crafter/)
-- :shield: [Warden — governance & policy](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/warden/)
-- :sailboat: [Skipper — fleet-wide orchestration](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/skipper/)
-- :moneybag: [Editions](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/editions/)
-- :ocean: [FAQ](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/faq/)
-- :mega: [Releases](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/releases/)
-- :telescope: [Roadmap](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/roadmap/)
-- :scroll: [License](https://shipyard.naftiko.io/docs/1.0.0-alpha3/fleet/license/)
+- :compass: [Concepts — Spec-Driven Integration](https://shipyard.naftiko.io/ikanos/1.0.0-alpha4/concepts/spec-driven-integration/)
+- :ship: [Fleet Overview](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/index.html)
+- :hammer_and_wrench: [Crafter — the capability builder](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/crafter/)
+- :shield: [Warden — governance & policy](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/warden/)
+- :sailboat: [Skipper — fleet-wide orchestration](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/skipper/)
+- :ocean: [FAQ](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/faq/)
+- :mega: [Releases](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/releases/)
+- :telescope: [Roadmap](https://shipyard.naftiko.io/fleet/1.0.0-alpha4/roadmap/)
 
 ## :video_game: Try it in the Playground
 
-Want to see the Fleet in action without installing anything? The upcoming **Shipyard Playground** lets you author a capability with **Crafter**, lint it live with **Polychro**, and serve it with **Ikanos** — all from your browser. Keep an eye on the [Shipyard](https://shipyard.naftiko.io/docs/1.0.0-alpha3/) for its release.
+Want to see the Fleet in action without installing anything? The **[Playground](https://shipyard.naftiko.io/playground)**. Jump straight into a guided tutorial:
+
+- **[Track 1 — Context Engineering](https://shipyard.naftiko.io/playground/tutorial/1)** (mock → live → auth → shaping → legacy → writes → lookups)
+- **[Track 2 — API Reusability](https://shipyard.naftiko.io/playground/tutorial/8)** (skill groups → aggregates → REST)
+- **[Track 3 — API Orchestration](https://shipyard.naftiko.io/playground/tutorial/11)** (the Fleet Manifest capstone)
 
 ***
 


### PR DESCRIPTION
## Summary

Refreshes the Fleet README for the **alpha4** release and makes the hosted Playground easy to reach so people can test without installing anything.

## Changes

- **Fixed broken links** — every Shipyard link now points to `1.0.0-alpha4` (intro Spec-Driven Integration link + all deep-dive links: Concepts, Fleet Overview, Crafter, Warden, Skipper, FAQ, Releases, Roadmap, License).
- **Live Playground** — replaced the old "upcoming / coming soon" note with a direct link to [shipyard.naftiko.io/playground](https://shipyard.naftiko.io/playground) and three guided tutorial tracks (Context Engineering, API Reusability, API Orchestration), mirroring the Ikanos README.
- **Rebrand** — README now presents the Fleet as the Enterprise platform and lists the three product components (Crafter, Warden, Skipper).
- **LICENSE.md** — updated to the alpha4 free-for-testing notice.

## Verification

- No remaining `alpha3` / "coming soon" / "upcoming" references in the README.
