### PR TITLE
feat: npm audit prod dep

### DIFF
--- a/.github/workflows/publish-naftiko-crafter-assets.yml
+++ b/.github/workflows/publish-naftiko-crafter-assets.yml
@@ -55,6 +55,14 @@ jobs:
         run: npm ci
         working-directory: extensions/naftiko-crafter
 
+      - name: Audit production dependencies
+        # Scoped to --omit=dev: devDependencies (test/build tooling) are never bundled into
+        # the VSIX by `vsce package`, so auditing them here would gate releases on CVEs in
+        # code that isn't actually shipped. Fails the job (npm audit's own exit code) on
+        # any HIGH/CRITICAL finding in what's actually published.
+        run: npm audit --omit=dev --audit-level=high
+        working-directory: extensions/naftiko-crafter
+
       - name: Fetch Polychro native binaries
         # Source selection:
         #  - Default (release events / manual without run id): pull the binaries from a


### PR DESCRIPTION
## Related Issue

Partially closes https://github.com/naftiko/crafter/issues/102

---

## What does this PR do?
adding a step npm audit --omit=dev --audit-level=high right after npm ci, before vsce package. 

Gate on the native exit code from npm audit (no additional configuration). --omit=dev intentionally scopes the audit to what is actually bundled in the published .vsix.

---

## Checklist

- [ ] CI is green (build, tests, schema validation, security scans)
- [ ] Rebased on latest `main`
- [ ] Small and focused — one concern per PR
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

